### PR TITLE
(untested) added autoFullscreen option

### DIFF
--- a/draw.js
+++ b/draw.js
@@ -52,6 +52,16 @@ exports.clientVars = function(hook, context, callback){
     draw.position = "right";
   }
 
+  try {
+    if(settings.ep_draw.autoFullscreen){
+      draw.autoFullscreen = true;
+    }else{
+      draw.autoFullscreen = false;
+    }
+  } catch (e){
+    draw.autoFullscreen = false;
+  }
+
 
   return callback( { "ep_draw": draw } );
 };

--- a/static/js/draw.js
+++ b/static/js/draw.js
@@ -90,9 +90,13 @@ function toggledraw(){
     hidedraw();
     return;
   }
-  if(!clientVars.ep_draw.visible){
+
+  if(!clientVars.ep_draw.visible && !clientVars.ep_draw.autoFullscreen){
     showdraw();
     return;
+  } else if(!clientVars.ep_draw.visible && clientVars.ep_draw.autoFullscreen){
+    fullScreenDraw();
+    return; 
   }
   if(clientVars.ep_draw.visible === true && !clientVars.ep_draw.fullscreen){
     fullScreenDraw();


### PR DESCRIPTION
Fix for #36 

immediately open in fullscreen when clicking the draw icon.

In the readme we should add:

## To automatically open the pad in fullscreen
```json
    "ep_draw": {
        "autoFullscreen": true
    }
```